### PR TITLE
Force an ionic overlay to be displayed where possible

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -316,7 +316,7 @@ angular.module('google.places', [])
     ])
 
 
-    .directive('gPlacesAutocompleteDrawer', ['$window', '$document', function ($window, $document) {
+    .directive('gPlacesAutocompleteDrawer', ['$window', '$document', '$injector', '$timeout', function ($window, $document, $injector, $timeout) {
         var TEMPLATE = [
             '<div class="pac-container" ng-if="isOpen()" ng-style="{top: position.top+\'px\', left: position.left+\'px\', width: position.width+\'px\'}" style="display: block;" role="listbox" aria-hidden="{{!isOpen()}}">',
             '  <div class="pac-item" g-places-autocomplete-prediction index="$index" prediction="prediction" query="query"',
@@ -358,6 +358,19 @@ angular.module('google.places', [])
                 };
 
                 $scope.$watch('predictions.length', function () {
+                    try {
+                        var $ionicBackdrop = $injector.get('$ionicBackdrop');
+                        if ($scope.predictions.length) {
+                            $ionicBackdrop._element.css('background-color', 'transparent');
+                            $ionicBackdrop.retain();
+                        } else {
+                            $ionicBackdrop.release();
+                            $timeout(function () {
+                                $ionicBackdrop._element.css('background-color', '');
+                            }, 200);
+                        }
+                    } catch (err) {}
+
                     $scope.position = getDrawerPosition($scope.input);
                 });
 


### PR DESCRIPTION
Towards #1520

$ionicBackdrop is activated if
- Ionic framework is present
- The suggestions are visible

This repo is also going out of sync with the parent.
Nothing has been done to resolve that.
