### PR TITLE
Fix no-address masking

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -361,7 +361,9 @@ angular.module('google.places', [])
                     try {
                         var $ionicBackdrop = $injector.get('$ionicBackdrop');
                         if ($scope.predictions.length) {
-                            $ionicBackdrop._element.css('background-color', 'transparent');
+                            $ionicBackdrop._element
+                                .css('background-color', 'transparent');
+                            $ionicBackdrop.release();
                             $ionicBackdrop.retain();
                         } else {
                             $ionicBackdrop.release();


### PR DESCRIPTION
$ionicPopup does not expose the number of times that it has been called. The only workaround for this is releasing the topmost mask before requesting one to be retained.
